### PR TITLE
#46263 Encapsulating the describe keyspace command with double quotes…

### DIFF
--- a/cassandra_backup_service.py
+++ b/cassandra_backup_service.py
@@ -931,7 +931,7 @@ class Cassandra(object):
         cmd = [
             'cqlsh',
             '-e',
-            'DESCRIBE KEYSPACE {0}'.format(keyspace),
+            'DESCRIBE KEYSPACE "{0}"'.format(keyspace),
         ]
 
         append_cqlsh_args(cmd, args)


### PR DESCRIPTION
… to handle case sensitive keyspaces when sending the CQLSH command.